### PR TITLE
Back

### DIFF
--- a/api/Locations/Controller.js
+++ b/api/Locations/Controller.js
@@ -62,11 +62,19 @@ const paths = [
         }).code(200);
       },
       (error) => {
-        res({
-          statusCode: 500,
-          message: 'Failed to get Location',
-          error,
-        }).code(500);
+        if (error.code === 404) {
+          res({
+            statusCode: 404,
+            message: 'Location does not exist',
+            error,
+          }).code(404);
+        } else {
+          res({
+            statusCode: 500,
+            message: 'Failed to get Location',
+            error,
+          }).code(500);
+        }
       });
     },
   },
@@ -74,7 +82,7 @@ const paths = [
     method: 'GET',
     path: '/{id}/count',
     handler: (req, res) => {
-      Service.getLocationCount(req.params.id).then(
+      Service.getLocationCount(req.params.id, req.query).then(
       (result) => {
         res({
           statusCode: 200,
@@ -83,11 +91,19 @@ const paths = [
         }).code(200);
       },
       (error) => {
-        res({
-          statusCode: 500,
-          message: 'Failed to count for Location',
-          error,
-        }).code(500);
+        if (error.code === 404) {
+          res({
+            statusCode: 404,
+            message: 'Location does not exist',
+            error,
+          }).code(404);
+        } else {
+          res({
+            statusCode: 500,
+            message: 'Failed to count for Location',
+            error,
+          }).code(500);
+        }
       });
     },
   },


### PR DESCRIPTION
Added Timeslice querying
- with `start`, `end`, and `slice` query parameters, `/api/locations/{id}/count` can calculate multiple - - values over a section of time
  - `start` and `end` must be ISO 8601 strings
  - `slice` is the number of min that each slice will account for
    - Time slices are paritioned from end to start, calculating only full slices; no partial slices are calculated at the start

Implemented a rejection system for alternate reasons, namely for a resource not existing reporting such a fact rather than a generic server error.
- For example, `/api/locations/{id}` **GET** now reports `404` if that **_id_** does not exist in the database